### PR TITLE
Ignore character controller

### DIFF
--- a/bullet/src/extensions/ccRayResultCallback.h
+++ b/bullet/src/extensions/ccRayResultCallback.h
@@ -15,6 +15,14 @@ typedef btCollisionWorld::ClosestRayResultCallback ClosestRayResultCallback;
 typedef btCollisionWorld::AllHitsRayResultCallback AllHitsRayResultCallback;
 typedef btCollisionWorld::LocalRayResult LocalRayResult;
 
+namespace {
+	bool isCharacterController(btCollisionObject* obj) {
+		uintptr_t userPointer = reinterpret_cast<uintptr_t>(obj->getUserPointer());
+		// character controller set user pointer in CapsuleCharacterController_new().
+		return (userPointer == static_cast<uintptr_t>(0xffffffff));
+	}
+}
+
 struct ccClosestRayResultCallback : public ClosestRayResultCallback
 {
 	int m_shapeUserPointer;
@@ -29,9 +37,14 @@ struct ccClosestRayResultCallback : public ClosestRayResultCallback
 	// return true when pairs need collision
 	virtual bool needsCollision(btBroadphaseProxy* proxy0) const
 	{
+		btCollisionObject* co = static_cast<btCollisionObject*>(proxy0->m_clientObject);
+		// Ignore charactor controller as Physx doesn't handle it in raycast.
+		if (isCharacterController(co)) {
+            return false;
+        }
+
 		if ((proxy0->m_collisionFilterGroup & m_collisionFilterMask) != 0) {			
 			if (!m_queryTrigger && proxy0->m_clientObject) {
-				btCollisionObject* co = static_cast<btCollisionObject*>(proxy0->m_clientObject);
 				return co->hasContactResponse();
 			}
 			return true;
@@ -95,9 +108,14 @@ struct ccAllHitsRayResultCallback : public AllHitsRayResultCallback
 	// return true when pairs need collision
 	virtual bool needsCollision(btBroadphaseProxy* proxy0) const
 	{
+		btCollisionObject* co = static_cast<btCollisionObject*>(proxy0->m_clientObject);
+		// Ignore charactor controller as Physx doesn't handle it in raycast.
+		if (isCharacterController(co)) {
+            return false;
+        }
+
 		if ((proxy0->m_collisionFilterGroup & m_collisionFilterMask) != 0) {			
 			if (!m_queryTrigger && proxy0->m_clientObject) {
-				btCollisionObject* co = static_cast<btCollisionObject*>(proxy0->m_clientObject);
 				return co->hasContactResponse();
 			}
 			return true;

--- a/bullet/src/extensions/ccRayResultCallback.h
+++ b/bullet/src/extensions/ccRayResultCallback.h
@@ -40,8 +40,8 @@ struct ccClosestRayResultCallback : public ClosestRayResultCallback
 		btCollisionObject* co = static_cast<btCollisionObject*>(proxy0->m_clientObject);
 		// Ignore charactor controller as Physx doesn't handle it in raycast.
 		if (isCharacterController(co)) {
-            return false;
-        }
+                    return false;
+                }
 
 		if ((proxy0->m_collisionFilterGroup & m_collisionFilterMask) != 0) {			
 			if (!m_queryTrigger && proxy0->m_clientObject) {
@@ -111,8 +111,8 @@ struct ccAllHitsRayResultCallback : public AllHitsRayResultCallback
 		btCollisionObject* co = static_cast<btCollisionObject*>(proxy0->m_clientObject);
 		// Ignore charactor controller as Physx doesn't handle it in raycast.
 		if (isCharacterController(co)) {
-            return false;
-        }
+                    return false;
+                }
 
 		if ((proxy0->m_collisionFilterGroup & m_collisionFilterMask) != 0) {			
 			if (!m_queryTrigger && proxy0->m_clientObject) {

--- a/bullet/webBinding/character-controller.cpp
+++ b/bullet/webBinding/character-controller.cpp
@@ -183,7 +183,14 @@ extern "C"
         btCollisionWorld *world = (btCollisionWorld *)collisionWorld;
         btCapsuleCharacterControllerDesc *desc = (btCapsuleCharacterControllerDesc *)ptrBtCapsuleCharacterControllerDesc;
         void* ptr = (void*)userObjectPointer;
-        return (int)new btCapsuleCharacterController(world, desc, ptr);
+        auto* controller = new btCapsuleCharacterController(world, desc, ptr);
+
+        btGhostObject* ghostObject = controller->getGhostObject();
+        uintptr_t intAsPointer = static_cast<uintptr_t>(0xffffffff);
+        void* userPointer = reinterpret_cast<void*>(intAsPointer);
+        ghostObject->setUserPointer(userPointer);
+
+        return (int)controller;
     }
 
     void DLL_EXPORT CapsuleCharacterController_setRadius(int ptrCCT, float radius)


### PR DESCRIPTION
In physx, character controller is not detected in raycast. And the bullet js implementation doesn't handle it correctly in ray cast.

May support character controller in raycast in future. But should modify physx too.